### PR TITLE
fixed cpu affinity for child processes

### DIFF
--- a/affinity.ps1
+++ b/affinity.ps1
@@ -50,6 +50,7 @@ Start-Process -NoNewWindow -PassThru -FilePath ".\BlackDesertPatcher32.pae" @arg
 $time = (Get-Date).AddSeconds(5)
 
 do {
+    # Wait for child process to start and then set selected CPU affinity
     start-sleep -Seconds 2
     $status = Get-BDOProcess
     if($status) {

--- a/affinity.ps1
+++ b/affinity.ps1
@@ -21,6 +21,11 @@ function Get-UserAdminState {
     $currentUser.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
 }
 
+#
+function Get-BDOProcess {
+    Get-Process BlackDesertPatcher32.pae -ErrorAction SilentlyContinue
+}
+
 if ((Get-UserAdminState) -eq $false) {
     if (!$elevated) {
         Start-Process powershell.exe -WindowStyle Hidden -Verb RunAs -ArgumentList ('-ExecutionPolicy Bypass -NoLogo -NoProfile -File "{0}" -elevated' -f ($myinvocation.MyCommand.Definition))
@@ -43,10 +48,14 @@ Start-Process -NoNewWindow -PassThru -FilePath ".\BlackDesertPatcher32.pae" @arg
 # Attempt to get the patcher's process
 # If not found after 5 seconds just end the script.
 $time = (Get-Date).AddSeconds(5)
+
 do {
-    $status = Get-Process BlackDesertPatcher32.pae -ErrorAction SilentlyContinue
+    start-sleep -Seconds 2
+    $status = Get-BDOProcess
     if($status) {
-        $status.ProcessorAffinity=$affinity
+        $status | ForEach-Object {
+             $_.ProcessorAffinity = $affinity 
+        }
         exit
     }
 } while((!$status) -and (Get-Date) -lt $time)

--- a/affinity.ps1
+++ b/affinity.ps1
@@ -16,12 +16,12 @@ $affinity = 21845
 
 
 # Ask for admin as BDO binaries requires it.
-function Check-Admin {
+function Get-UserAdminState {
     $currentUser = New-Object Security.Principal.WindowsPrincipal $([Security.Principal.WindowsIdentity]::GetCurrent())
     $currentUser.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
 }
 
-if ((Check-Admin) -eq $false) {
+if ((Get-UserAdminState) -eq $false) {
     if (!$elevated) {
         Start-Process powershell.exe -WindowStyle Hidden -Verb RunAs -ArgumentList ('-ExecutionPolicy Bypass -NoLogo -NoProfile -File "{0}" -elevated' -f ($myinvocation.MyCommand.Definition))
     }
@@ -31,14 +31,14 @@ if ((Check-Admin) -eq $false) {
 # cd first into folder instead of accesing the file directly
 # otherwise the PALauncher makes you re-download the game again for some odd-reason.
 $path = Split-Path $script:MyInvocation.MyCommand.Path
-cd $path
+Set-Location $path
 
 # Detect if this is the steam version of BDO
 $arg = @{}
 if(Test-Path -Path ".\steam_api.dll") { $arg["ArgumentList"] = "--steam" }
 
 # Launch BDO's patcher
-$app = Start-Process -NoNewWindow -PassThru -FilePath ".\BlackDesertPatcher32.pae" @arg
+Start-Process -NoNewWindow -PassThru -FilePath ".\BlackDesertPatcher32.pae" @arg
 
 # Attempt to get the patcher's process
 # If not found after 5 seconds just end the script.


### PR DESCRIPTION
This should fix the problem that child processes, launched by the patcher didn't get the correct CPU affinity